### PR TITLE
Change sort order from descending to ascending

### DIFF
--- a/src/pages/api/status.tsx
+++ b/src/pages/api/status.tsx
@@ -14,7 +14,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const records = await base("Users")
       .select({
         filterByFormula: `OR({Email} = '${data.email}', {Hack Club Slack ID} = '${data.slack_id}')`,
-        sort: [{ field: "Created At", direction: "desc" }],
+        sort: [{ field: "Created At", direction: "asc" }],
       })
       .all();
 


### PR DESCRIPTION
This should make sure that if duplicate verification records exist in Airtable, only the newest one gets returned by the API.