### PR TITLE
fix(api/status): Change formula to allow for spaces in User ID

### DIFF
--- a/src/pages/api/status.tsx
+++ b/src/pages/api/status.tsx
@@ -13,7 +13,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const records = await base("Users")
       .select({
-        filterByFormula: `OR({Email} = '${data.email}', {Hack Club Slack ID} = '${data.slack_id}')`,
+        filterByFormula: `OR({Email} = '${data.email}', TRIM({Hack Club Slack ID}) = '${data.slack_id}')`,
         sort: [{ field: "Created At", direction: "desc" }],
       })
       .all();


### PR DESCRIPTION
Some people accidentally add whitespace to their User IDs when verifying (there've been a few instances of this in the #nest channel where people have gotten their verification success email, but aren't allowed to sign up because "they aren't verified").

This PR updates the Airtable filter formula from:
```
OR({Email} = '${data.email}', {Hack Club Slack ID} = '${data.slack_id}')
```
to:
```
OR({Email} = '${data.email}', TRIM({Hack Club Slack ID}) = '${data.slack_id}')
```

The new formula trims the Slack ID before comparing it to the Slack ID given, which should stop the issue above from occuring. Obviously, it would be nicer if the whitespace wasn't in the user ID in the first place, but this PR avoids an admin having to go into Airtable and fixing the issue manually.